### PR TITLE
typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # open-workflows
 
-List of open workflows and resources for a/v archiving. Please contribute!  
+List of open workflows and resources for A/V archiving. Please contribute!  
 
-If you have never contributed to Github before, [here is a guide](http://ablwr.github.io/blog/2014/11/04/non-technical-persons-guide-to-becoming-an-open-source-software-contributor-via-github/)! You can also [file an issue](https://github.com/amiaopensource/open-workflows/issues/new) (which is like filling out a form) and someone else will add it.
+If you have never contributed to GitHub before, [here is a guide](http://ablwr.github.io/blog/2014/11/04/non-technical-persons-guide-to-becoming-an-open-source-software-contributor-via-github/)! You can also [file an issue](https://github.com/amiaopensource/open-workflows/issues/new) (which is like filling out a form) and someone else will add it.
 
 ## Documentation
 
-- [Andy Warhol Museum Digital Strategy](https://github.com/thewarholmuseum/digital-strategy/): A versioned digital strategy repository for The Andy Warhol Museum
+- [Andy Warhol Museum Digital Strategy](https://github.com/thewarholmuseum/digital-strategy/): A versioned digital strategy repository for The Andy Warhol Museum.
 - [Archivematica Development Wiki](https://wiki.archivematica.org/Main_Page)
 - [Collective Access Community: Guides and Workflows](http://collectiveaccesscommunity.org/category/guides/)
 - [Digital Processing, Bentley Historical Library](https://sites.google.com/a/umich.edu/bhl-archival-curation/processing-archival-collections/08-digital-processing): Workflow for ingesting digital objects at the Bentley Historial Library.
 - [Format Migrations at Harvard](http://blogs.loc.gov/thesignal/2015/04/format-migrations-at-harvard-library-an-ndsr-project-update/)
-- [Library Workflow Exchange](http://www.libraryworkflowexchange.org/): A site designed to help librarians share workflows and best practices across institutions
-- [Personal Digital Archiving Day Kit](http://www.digitalpreservation.gov/personalarchiving/padKit/index.html): Robust documentation around organizing and hosting a Personal Archiving Day, including a/v resources.
+- [Library Workflow Exchange](http://www.libraryworkflowexchange.org/): A site designed to help librarians share workflows and best practices across institutions.
+- [Personal Digital Archiving Day Kit](http://www.digitalpreservation.gov/personalarchiving/padKit/index.html): Robust documentation around organizing and hosting a Personal Archiving Day, including A/V resources.
 - [UCLA Quality Control Workflow](https://www.library.ucla.edu/sites/default/files/Guidelines_MetadataQualityControl.pdf): (PDF)
 - [University of Michigan ICPSR](http://www.icpsr.umich.edu/icpsrweb/content/datamanagement/preservation/index.html): "This guide describes digital preservation practices at ICPSR, the primary objective of which is to ensure long-term access to the more than 500,000 files in our collection."
 - [University of Washington Media Center](https://github.com/pugetsoundandvision/information/blob/master/UWMC/Open%20Reel%20(Reel%20to%20Reel)%20Tape%20Digitization%20Guide.md): Step by step documentation of open-reel audio digitization workflow in place at the University of Washington Libraries Media Center.
@@ -21,10 +21,10 @@ If you have never contributed to Github before, [here is a guide](http://ablwr.g
 
 ## Transfer stations and digitization labs
 - [Brooklyn Public Library Info Commons](http://www.bklynlibrary.org/conversion)
-- [DC Public Library Memory Lab](http://libguides.dclibrary.org/memorylab): How to transfer formats (specific to their setup but applicable elsewhere)
+- [DC Public Library Memory Lab](http://libguides.dclibrary.org/memorylab): How to transfer formats (specific to their setup but applicable elsewhere).
 - [Indiana University Scholar Commons Digitization Lab](https://libraries.indiana.edu/scholars-commons-digitization-lab)
 - [Kalamazoo Public Library The Hub](http://www.kpl.gov/hub/)
-- [On Personal Archiving Labs](https://samabrams.wordpress.com/2016/07/28/on-personal-archiving-labs/): Blog post by Sam Abrams on setting up a personal archiving lab for Madison Public Library
+- [On Personal Archiving Labs](https://samabrams.wordpress.com/2016/07/28/on-personal-archiving-labs/): Blog post by Sam Abrams on setting up a personal archiving lab for Madison Public Library.
 - [UW Media Arcade](http://guides.lib.uw.edu/c.php?g=342258&p=2300599): A digital A/V makerspace that supports media creation, preservation and use.
 - [University of Wisconsin-Madison RADD](http://radd.dsalo.info/index.php/category/how-tos/) How-to guides to digitizationa
 - [XFR Collective](https://github.com/XFRCollective)
@@ -33,32 +33,32 @@ If you have never contributed to Github before, [here is a guide](http://ablwr.g
 ## Resources
 
 - [analog-inspection](https://github.com/amiaopensource/analog-inspection): List of analog media inspection templates/forms.
-- [audio-digitization-toolkit](https://github.com/todrobbins/audio-digitization-toolkit): A list of resources for setting up an audio digitization workflow  
+- [audio-digitization-toolkit](https://github.com/todrobbins/audio-digitization-toolkit): A list of resources for setting up an audio digitization workflow.
 - [A/V Artifact Atlas](http://avaa.bavc.org/artifactatlas/index.php/A/V_Artifact_Atlas): For use in the identification and definition of the technical issues and anomalies that can afflict audio and video signals.
-- [cable-bible](https://github.com/amiaopensource/cable-bible): A guide to cables and connectors used for audiovisual tech
+- [cable-bible](https://github.com/amiaopensource/cable-bible): A guide to cables and connectors used for audiovisual tech.
 - [Cleaning Digibetas](https://bitbucket.co.uk/work/db_cleaning.html)
 - [Community Owned digital Preservation Tool Registry (COPTR)](http://coptr.digipres.org/Main_Page): COPTR describes tools useful for long term digital presesrvation and acts primarily as a finding and evaluation tool to help practitioners find the tools they need to preserve digital data.
-- [Digital POWRR Tool Grid 2.0](http://www.digipres.org/tools/ubergrid/): an ubergrid of tools useful in digital preservation, and their role in the preservation lifecycle.
-- [Libraries Sharing Code](https://wiki.code4lib.org/Libraries_Sharing_Code): Wiki list of libraries sharing their code on Github or on other open repositories.
-- [media-id-posters](https://github.com/ablwr/media-id-posters): Visualized summaries of physical objects for a/v archivists
-- [No Time To Wait! Symposium](https://github.com/preforma/notimetowait): Documentation around conference including slides and videos on talks focused around Matroska and FFV1 workflows
+- [Digital POWRR Tool Grid 2.0](http://www.digipres.org/tools/ubergrid/): An ubergrid of tools useful in digital preservation, and their role in the preservation lifecycle.
+- [Libraries Sharing Code](https://wiki.code4lib.org/Libraries_Sharing_Code): Wiki list of libraries sharing their code on GitHub or on other open repositories.
+- [media-id-posters](https://github.com/ablwr/media-id-posters): Visualized summaries of physical objects for A/V archivists.
+- [No Time To Wait! Symposium](https://github.com/preforma/notimetowait): Documentation around conference including slides and videos on talks focused around Matroska and FFV1 workflows.
 - [QCTools Cheat Sheet](https://docs.google.com/document/d/1xat34KWmMwmz8lzXPUACItPdGFR_kBv43Vu6Qkeaov4/edit)
 - [UW Audio Preservation and Resoration Guide](http://guides.lib.uw.edu/research/AudioPreservation) Large aggregation of Audio resources with descriptions.
 
 ## Scripts
 
-- [Carnegie Hall](https://github.com/CarnegieHall): Post-digitization quality control workflow documentation and scripts; Scripts and overview documentation for generating linked data from event records; and scripts and documentation detailing workflow for batch linking metadata records from disparate CSVs to files.
-- [CUNY mediamicroservices](https://github.com/mediamicroservices/mm): Suite of bash scripts for a/v archiving  
+- [Carnegie Hall](https://github.com/CarnegieHall): Post-digitization quality control workflow documentation and scripts; scripts and overview documentation for generating linked data from event records; and scripts and documentation detailing workflow for batch linking metadata records from disparate CSVs to files.
+- [CUNY mediamicroservices](https://github.com/mediamicroservices/mm): Suite of bash scripts for A/V archiving  
 - [ffmprovisr](https://github.com/amiaopensource/ffmprovisr): Repository of useful FFmpeg command lines for archivists! 
 - [IFIscripts](https://github.com/kieranjol/IFIscripts): Scripts for video/DCP/image sequences/fixity for use in the IFI Irish Film Archive. 
 - [National Library of New Zealand (NLNZ)](https://github.com/NLNZDigitalPreservation): Scripts for generating METS records, Rosetta-compliant SIPs, etc.
-- [New York Times video microservices](http://open.blogs.nytimes.com/2016/11/01/using-microservices-to-encode-and-publish-videos-at-the-new-york-times/): Documentation and links to services scripts
+- [New York Times video microservices](http://open.blogs.nytimes.com/2016/11/01/using-microservices-to-encode-and-publish-videos-at-the-new-york-times/): Documentation and links to services scripts.
 - [Puget Sound and Vision Audio Scripts](https://github.com/pugetsoundandvision/audiotools): Bash scripts/documentation used at University of Washington for moving from a digitized WAV file to a package including BWF, TIFFs and derivatives.
-- [Rockefeller Center Archives transfer_workflow](https://github.com/RockefellerArchiveCenter/transfer_workflow): Digital media transfer workflow documentation
-- [ucsb-src-microservices](https://github.com/brnco/ucsb-src-microservices): post-processing scripts we use at UCSB Special Research Collections AVLab
+- [Rockefeller Center Archives transfer_workflow](https://github.com/RockefellerArchiveCenter/transfer_workflow): Digital media transfer workflow documentation.
+- [ucsb-src-microservices](https://github.com/brnco/ucsb-src-microservices): Post-processing scripts we use at UCSB Special Research Collections AVLab.
 - [U.S. National Archives](https://github.com/usnationalarchives)
 - [WGBH preservation-workflows](https://github.com/WGBH/preservation-workflow): Useful scripts to help automate common WGBH Media Library and Archive digital preservation workflows into a single preserve.rb Ruby script.
-- [Yale University Libraries](https://github.com/yalemssa): Manuscripts and Archives Github
+- [Yale University Libraries](https://github.com/yalemssa): Manuscripts and Archives GitHub.
 
 ## Tools
 
@@ -67,5 +67,5 @@ If you have never contributed to Github before, [here is a guide](http://ablwr.g
 - [MediaConch](https://github.com/MediaArea/MediaConch_SourceCode): Tool for quickly creating and comparing policies for digital media to ensure compliance with chosen standards.
 - [MediaInfo](https://mediaarea.net/en/MediaInfo): Essential tool for quick analysis of A/V file metadata.
 - [qctools](github.com/bavc/qctools): Enables extensive analysis of digitized video for quality control purposes.
-- [vrecord](https://github.com/amiaopensource/vrecord): Open source tool for analog video digitization. Includes a variety of virtual scopes.  Requires [Blackmagic](https://www.blackmagicdesign.com/products) hardware. 
-- [XLD](http://tmkk.undo.jp/xld/index_e.html): Tool for lossless transcoding of various audio formats.  Useful for error free CD ripping.
+- [vrecord](https://github.com/amiaopensource/vrecord): Open source tool for analog video digitization. Includes a variety of virtual scopes. Requires [Blackmagic](https://www.blackmagicdesign.com/products) hardware. 
+- [XLD](http://tmkk.undo.jp/xld/index_e.html): Tool for lossless transcoding of various audio formats. Useful for error free CD ripping.


### PR DESCRIPTION
- uniformed the use of A/V over a/v
- all descriptions end with a period
- GitHub