### PR TITLE
add DMIA guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Sibling repositories: [analog-inspection](https://github.com/amiaopensource/anal
 - [Cassette Decks: Buying Guide](https://www.cs.cmu.edu/~./gdead/taping-guide/part1.html)
 - [Cleaning Digibetas](https://bitbucket.co.uk/work/db_cleaning.html)
 - [Community Owned digital Preservation Tool Registry (COPTR)](http://coptr.digipres.org/Main_Page): COPTR describes tools useful for long term digital preservation and acts primarily as a finding and evaluation tool to help practitioners find the tools they need to preserve digital data.
+- [DMIA: Digital Moving Image Archives](https://sites.google.com/site/dmiaguide/): a guide designed for independent filmmakers to provide basic information about preserving digital data and to encourage collaboration with moving image archives.
 - [Digital POWRR Tool Grid 2.0](http://www.digipres.org/tools/ubergrid/): An ubergrid of tools useful in digital preservation, and their role in the preservation lifecycle.
 - [Libraries Sharing Code](https://wiki.code4lib.org/Libraries_Sharing_Code): Wiki list of libraries sharing their code on GitHub or on other open repositories.
 - [Matters in Media Art Assessment Workstation](http://mattersinmediaart.org/assessing-time-based-media-art.html#workstation)


### PR DESCRIPTION
"The DMIA guide is a cost-effective plan based on archival best-practices for personal digital preservation. Rather than focus on individual file formats or specific “archival standard” formats (which don’t exist), the purpose is to provide a road map for digital survival."